### PR TITLE
remove html5.js

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,10 +3,7 @@
 <head>
 	<meta charset="utf-8" />
 	<title>Basis Documents</title>
-	<!--[if IE]>
-	<script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
-	<![endif]-->
-	
+
 	<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.1.0/styles/railscasts.min.css">
 	<script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.1.0/highlight.min.js"></script>
 	<script>hljs.initHighlightingOnLoad();</script>


### PR DESCRIPTION
要件的に不要なのと、GoogleCodeが閉鎖されるため。